### PR TITLE
Do not fail on nil money values

### DIFF
--- a/lib/avo/money_field/fields/money_field.rb
+++ b/lib/avo/money_field/fields/money_field.rb
@@ -25,7 +25,7 @@ module Avo
         end
 
         def currency
-          value.send(:currency)
+          value && value.send(:currency)
         end
 
         def currency_column


### PR DESCRIPTION
If the model's money attribute can be nil, this field fails when in edit mode.