### PR TITLE
fix: Allow disabling currency input

### DIFF
--- a/lib/avo/money_field/fields/money_field.rb
+++ b/lib/avo/money_field/fields/money_field.rb
@@ -4,7 +4,7 @@ module Avo
       class MoneyField < Avo::Fields::BaseField
         attr_reader :currencies
         attr_reader :currency_suffix
-        attr_reader :disable_currency
+        attr_reader :enable_currency
 
         def initialize(id, **args, &block)
           super(id, **args, &block)
@@ -12,7 +12,7 @@ module Avo
           add_array_prop args, :currencies
           currency_suffix = defined?(MoneyRails) ? ::MoneyRails::Configuration.currency_column[:postfix] : :_currency
           add_string_prop args, :currency_suffix, currency_suffix
-          add_boolean_prop args, :disable_currency, false
+          add_boolean_prop args, :enable_currency, true
         end
 
         def to_permitted_param
@@ -21,7 +21,7 @@ module Avo
 
         def fill_field(record, key, value, params)
           record.public_send(:"#{key}=", value)
-          record.public_send(:"#{key}#{@currency_suffix}=", params[:"#{key}#{@currency_suffix}"]) unless disable_currency
+          record.public_send(:"#{key}#{@currency_suffix}=", params[:"#{key}#{@currency_suffix}"]) if enable_currency
 
           record
         end

--- a/lib/avo/money_field/fields/money_field.rb
+++ b/lib/avo/money_field/fields/money_field.rb
@@ -4,6 +4,7 @@ module Avo
       class MoneyField < Avo::Fields::BaseField
         attr_reader :currencies
         attr_reader :currency_suffix
+        attr_reader :disable_currency
 
         def initialize(id, **args, &block)
           super(id, **args, &block)
@@ -11,6 +12,7 @@ module Avo
           add_array_prop args, :currencies
           currency_suffix = defined?(MoneyRails) ? ::MoneyRails::Configuration.currency_column[:postfix] : :_currency
           add_string_prop args, :currency_suffix, currency_suffix
+          add_boolean_prop args, :disable_currency, false
         end
 
         def to_permitted_param
@@ -19,7 +21,7 @@ module Avo
 
         def fill_field(record, key, value, params)
           record.public_send(:"#{key}=", value)
-          record.public_send(:"#{key}#{@currency_suffix}=", params[:"#{key}#{@currency_suffix}"])
+          record.public_send(:"#{key}#{@currency_suffix}=", params[:"#{key}#{@currency_suffix}"]) unless disable_currency
 
           record
         end

--- a/lib/avo/money_field/fields/money_field/edit_component.html.erb
+++ b/lib/avo/money_field/fields/money_field/edit_component.html.erb
@@ -10,7 +10,7 @@
       multiple: multiple,
       autocomplete: @field.autocomplete
     %>
-    <% if not @field.disable_currency %>
+    <% if @field.enable_currency %>
       <%= @form.select @field.currency_column,
         options_for_select(@field.currencies, selected: @field.currency),
         {},

--- a/lib/avo/money_field/fields/money_field/edit_component.html.erb
+++ b/lib/avo/money_field/fields/money_field/edit_component.html.erb
@@ -10,13 +10,15 @@
       multiple: multiple,
       autocomplete: @field.autocomplete
     %>
-    <%= @form.select @field.currency_column,
-      options_for_select(@field.currencies, selected: @field.currency),
-      {},
-      class: classes("w-24"),
-      disabled: disabled?,
-      value: @field.currency,
-      autocomplete: @field.autocomplete
-    %>
+    <% if not @field.disable_currency %>
+      <%= @form.select @field.currency_column,
+        options_for_select(@field.currencies, selected: @field.currency),
+        {},
+        class: classes("w-24"),
+        disabled: disabled?,
+        value: @field.currency,
+        autocomplete: @field.autocomplete
+      %>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Our app uses money but not the currency portion of it. This PR adds the ability to disable the currency input field. 